### PR TITLE
Calculate map bounds before re-draw

### DIFF
--- a/src/leaflet.canvas-markers.js
+++ b/src/leaflet.canvas-markers.js
@@ -191,13 +191,6 @@
     },
 
     _reset: function () {
-      var topLeft = this._map.containerPointToLayerPoint([0, 0]);
-      L.DomUtil.setPosition(this._canvas, topLeft);
-
-      var size = this._map.getSize();
-
-      this._canvas.width = size.x;
-      this._canvas.height = size.y;
       this._redraw();
     },
 
@@ -206,7 +199,15 @@
       if (!this._map) {
           return;
       }
+      
+      var topLeft = this._map.containerPointToLayerPoint([0, 0]);
+      L.DomUtil.setPosition(this._canvas, topLeft);
 
+      var size = this._map.getSize();
+
+      this._canvas.width = size.x;
+      this._canvas.height = size.y;
+      
       if (clear) {
         this._context.clearRect(0, 0, this._canvas.width, this._canvas.height);
       }


### PR DESCRIPTION
This fixes a bug where the markers don't update correctly when the map is moved by re-calculating the map boundaries before the re-draw takes place.